### PR TITLE
Added migration file for swappable Application model.

### DIFF
--- a/oauth_api/migrations/0003_auto_20160331_1731.py
+++ b/oauth_api/migrations/0003_auto_20160331_1731.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from oauth_api.settings import oauth_api_settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('oauth_api', '0002_auto_20150904_1155'),
+        migrations.swappable_dependency(oauth_api_settings.APPLICATION_MODEL),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='authorizationcode',
+            name='application',
+            field=models.ForeignKey(to=oauth_api_settings.APPLICATION_MODEL),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='refreshtoken',
+            name='application',
+            field=models.ForeignKey(to=oauth_api_settings.APPLICATION_MODEL),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='accesstoken',
+            name='application',
+            field=models.ForeignKey(to=oauth_api_settings.APPLICATION_MODEL),
+            preserve_default=True,
+        ),
+    ]

--- a/oauth_api/models.py
+++ b/oauth_api/models.py
@@ -95,7 +95,7 @@ class AccessToken(models.Model):
 
     user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
     token = models.CharField(max_length=255, db_index=True)
-    application = models.ForeignKey(oauth_api_settings.APPLICATION_MODEL)
+    application = models.ForeignKey(oauth_api_settings.APPLICATION_MODEL, swappable=True)
     expires = models.DateTimeField()
     scope = models.TextField(blank=True)
 
@@ -135,7 +135,7 @@ class AuthorizationCode(models.Model):
 
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
     code = models.CharField(max_length=255)
-    application = models.ForeignKey(oauth_api_settings.APPLICATION_MODEL)
+    application = models.ForeignKey(oauth_api_settings.APPLICATION_MODEL, swappable=True)
     expires = models.DateTimeField()
     redirect_uri = models.CharField(max_length=255)
     scope = models.TextField(blank=True)
@@ -161,7 +161,7 @@ class RefreshToken(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
     token = models.CharField(max_length=255)
     expires = models.DateTimeField(null=True, blank=True)
-    application = models.ForeignKey(oauth_api_settings.APPLICATION_MODEL)
+    application = models.ForeignKey(oauth_api_settings.APPLICATION_MODEL, swappable=True)
     access_token = models.OneToOneField(AccessToken,
                                         related_name='refresh_token')
 


### PR DESCRIPTION
Even if the user can override the `oauth_api_settings.APPLICATION_MODEL` attribute in the project settings to swap the `Application` model to another, the other tables that have a `ForeignKey` relation to the `Application` model had the model definition hardcoded instead of using the `migrations.swappable_dependency()` functionality, resulting in broken database layer. Added a migration file to fix this, ran `python runtests.py`:

`Ran 96 tests in 7.962s`

`OK`
